### PR TITLE
Fix Deprecated body2

### DIFF
--- a/lib/src/flutter_range_slider.dart
+++ b/lib/src/flutter_range_slider.dart
@@ -469,7 +469,7 @@ class _RangeSliderState extends State<RangeSlider>
       showValueIndicator:
           sliderTheme.showValueIndicator ?? _defaultShowValueIndicator,
       valueIndicatorTextStyle: sliderTheme.valueIndicatorTextStyle ??
-          theme.textTheme.body2.copyWith(
+          theme.textTheme.bodyText2.copyWith(
             color: theme.colorScheme.onPrimary,
           ),
     );


### PR DESCRIPTION
TextTheme.body2 is deprecated. now in flutter 2.5 it is TextTheme.bodyText2.